### PR TITLE
Deploy-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ prerequisites
 ##To run
 - to run this web you should have a webbrowser like chrome, safari, firefox...
 
+## Visit
+
+https://milindi7.github.io/portfolio-template-1/
 
 
 ## Authors


### PR DESCRIPTION
## What?
-deploy page
-add a link to the deployed link in README.md

## Why?
As required in the project, the README.md as a guide on the project should contain a link to the page.

## How?
After deploying the page and copying its link in the settings>page , I created #deploy-page 
branch and added the link into the README.md file for easy accessibility.